### PR TITLE
Fixing a nonexistent method call in loadView in UITableViewController

### DIFF
--- a/UIKit/Classes/UITableViewController.m
+++ b/UIKit/Classes/UITableViewController.m
@@ -47,7 +47,7 @@
 
 - (void)loadView
 {
-	self.tableView = [[[UITableView alloc] initWithStyle:_style] autorelease];
+	self.tableView = [[[UITableView alloc] initWithFrame:self.parentViewController.view.frame style:_style] autorelease];
 	self.tableView.delegate = self;
 	self.tableView.dataSource = self;
 }


### PR DESCRIPTION
The "initWithStyle:" method of UITableView was being called in UITableViewController. As far as I can see, UITableView has no such method. Now, the loadView method of UITableViewController calls "initWithFrame:style:", using the frame of the view of the parent view controller. I'm not sure if that's the correct frame to use, but from limited testing I can confirm that this works in my test app.
