### PR TITLE
UIWebViews should load content if they don't have a delegate

### DIFF
--- a/UIKit/Classes/UIWebView.m
+++ b/UIKit/Classes/UIWebView.m
@@ -159,7 +159,9 @@
 		}
 		
 		shouldStartLoad = [_delegate webView:self shouldStartLoadWithRequest:request navigationType:navType];
-	}
+	} else {
+        shouldStartLoad = YES;
+    }
 	
 	if (shouldStartLoad) {
 		[listener use];


### PR DESCRIPTION
..or they have a delegate that doesn't implement shouldStartLoadWithRequest. Otherwise UIWebViews are _always_ empty until this delegate & method are implemented (unlike the real UIKit).
