### PR TITLE
Re-add UIScreen.h to UIViewController.m

### DIFF
--- a/UIKit/Classes/UIViewController.m
+++ b/UIKit/Classes/UIViewController.m
@@ -29,6 +29,7 @@
 
 #import "UIViewController.h"
 #import "UIView+UIPrivate.h"
+#import "UIScreen.h"
 #import "UIWindow.h"
 #import "UINavigationItem.h"
 #import "UIBarButtonItem.h"


### PR DESCRIPTION
UIViewController still references a couple properties of UIScreen on [line 202](https://github.com/BigZaphod/Chameleon/blob/master/UIKit/Classes/UIViewController.m#L202), but the reference to the UIScreen.h header was removed in commit [77299fe2d](https://github.com/BigZaphod/Chameleon/commit/77299fe2dd4e1e0cd366f9fcc558a4d7c738a7db#L2L32). Xcode is giving me these Semantic Issues and refuses to build the project until I re-add UIScreen.h to UIViewController.m:

![Xcode errors](http://i.imgur.com/BGa1p.png)
