### PR TITLE
Add -description methods to several classes

### DIFF
--- a/UIKit/Classes/UIColor.m
+++ b/UIKit/Classes/UIColor.m
@@ -223,4 +223,28 @@ static UIColor *ClearColor = nil;
 	return theColor;
 }
 
+- (NSString *)description
+{
+	// The color space string this gets isn't exactly the same as Apple's implementation.
+	// For instance, Apple's implementation returns UIDeviceRGBColorSpace for [UIColor redColor]
+	// This implementation returns kCGColorSpaceDeviceRGB instead.
+	// Apple doesn't actually define UIDeviceRGBColorSpace or any of the other responses anywhere public,
+	// so there isn't any easy way to emulate it.
+	CGColorSpaceRef colorSpaceRef = CGColorGetColorSpace(self.CGColor);
+	NSString *colorSpace = [NSString stringWithFormat:@"%@", (NSString *)CGColorSpaceCopyName(colorSpaceRef)];
+	// This could be done with a loop, but really...there are only 3 possible lengths.
+	size_t numberOfComponents = CGColorGetNumberOfComponents(self.CGColor);
+	NSLog(@"%lu", numberOfComponents);
+	NSString *componentsString;
+	const CGFloat *components = CGColorGetComponents(self.CGColor);
+	if (numberOfComponents == 2) {
+		componentsString = [NSString stringWithFormat:@"%.0f %.0f", components[0], components[1]];
+	} else if (numberOfComponents == 3) {
+		componentsString = [NSString stringWithFormat:@"%.0f %.0f %.0f", components[0], components[1], components[2]];
+	} else if (numberOfComponents == 4) {
+		componentsString = [NSString stringWithFormat:@"%.0f %.0f %.0f %.0f", components[0], components[1], components[2], components[3]];
+	}
+	return [NSString stringWithFormat:@"%@ %@", colorSpace, componentsString];
+}
+
 @end

--- a/UIKit/Classes/UIColor.m
+++ b/UIKit/Classes/UIColor.m
@@ -224,4 +224,28 @@ static UIColor *GroupTableViewBackgroundColor = nil;
 	return theColor;
 }
 
+- (NSString *)description
+{
+	// The color space string this gets isn't exactly the same as Apple's implementation.
+	// For instance, Apple's implementation returns UIDeviceRGBColorSpace for [UIColor redColor]
+	// This implementation returns kCGColorSpaceDeviceRGB instead.
+	// Apple doesn't actually define UIDeviceRGBColorSpace or any of the other responses anywhere public,
+	// so there isn't any easy way to emulate it.
+	CGColorSpaceRef colorSpaceRef = CGColorGetColorSpace(self.CGColor);
+	NSString *colorSpace = [NSString stringWithFormat:@"%@", (NSString *)CGColorSpaceCopyName(colorSpaceRef)];
+	// This could be done with a loop, but really...there are only 3 possible lengths.
+	size_t numberOfComponents = CGColorGetNumberOfComponents(self.CGColor);
+	NSLog(@"%lu", numberOfComponents);
+	NSString *componentsString;
+	const CGFloat *components = CGColorGetComponents(self.CGColor);
+	if (numberOfComponents == 2) {
+		componentsString = [NSString stringWithFormat:@"%.0f %.0f", components[0], components[1]];
+	} else if (numberOfComponents == 3) {
+		componentsString = [NSString stringWithFormat:@"%.0f %.0f %.0f", components[0], components[1], components[2]];
+	} else if (numberOfComponents == 4) {
+		componentsString = [NSString stringWithFormat:@"%.0f %.0f %.0f %.0f", components[0], components[1], components[2], components[3]];
+	}
+	return [NSString stringWithFormat:@"%@ %@", colorSpace, componentsString];
+}
+
 @end

--- a/UIKit/Classes/UIGestureRecognizer.m
+++ b/UIKit/Classes/UIGestureRecognizer.m
@@ -186,7 +186,7 @@
 			state = @"Cancelled";
 			break;
 		case UIGestureRecognizerStateFailed:
-			@"Failed";
+			state = @"Failed";
 			break;
 	}
 	return [NSString stringWithFormat:@"<%@: %p; state = %@; view = %@>", [self className], self, state, self.view];

--- a/UIKit/Classes/UIGestureRecognizer.m
+++ b/UIKit/Classes/UIGestureRecognizer.m
@@ -166,4 +166,30 @@
 {
 }
 
+- (NSString *)description
+{
+	NSString *state = @"";
+	switch (self.state) {
+		case UIGestureRecognizerStatePossible:
+			state = @"Possible";
+			break;
+		case UIGestureRecognizerStateBegan:
+			state = @"Began";
+			break;
+		case UIGestureRecognizerStateChanged:
+			state = @"Changed";
+			break;
+		case UIGestureRecognizerStateRecognized:
+			state = @"Recognized";
+			break;
+		case UIGestureRecognizerStateCancelled:
+			state = @"Cancelled";
+			break;
+		case UIGestureRecognizerStateFailed:
+			@"Failed";
+			break;
+	}
+	return [NSString stringWithFormat:@"<%@: %p; state = %@; view = %@>", [self className], self, state, self.view];
+}
+
 @end

--- a/UIKit/Classes/UIScreen.m
+++ b/UIKit/Classes/UIScreen.m
@@ -219,4 +219,9 @@ NSMutableArray *_allScreens = nil;
 	return nil;
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; bounds = {{%.0f, %.0f}, {%.0f, %.0f}}; mode = %@>", [self className], self, self.bounds.origin.x, self.bounds.origin.y, self.bounds.size.width, self.bounds.size.height, self.currentMode];
+}
+
 @end

--- a/UIKit/Classes/UIScreenMode.m
+++ b/UIKit/Classes/UIScreenMode.m
@@ -41,4 +41,9 @@
 	return [mode autorelease];
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; size = %f x %f>", [self className], self, self.size.width, self.size.height];
+}
+
 @end

--- a/UIKit/Classes/UIScrollView.m
+++ b/UIKit/Classes/UIScrollView.m
@@ -579,4 +579,9 @@ const NSUInteger UIScrollViewScrollAnimationFramesPerSecond = 60;
 {
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; frame = (%.0f %.0f; %.0f %.0f); clipsToBounds = %@; layer = %@; contentOffset = {%.0f, %.0f}>", [self className], self, self.frame.origin.x, self.frame.origin.y, self.frame.size.width, self.frame.size.height, (self.clipsToBounds ? @"YES" : @"NO"), self.layer, self.contentOffset.x, self.contentOffset.y];
+}
+
 @end

--- a/UIKit/Classes/UIScrollView.m
+++ b/UIKit/Classes/UIScrollView.m
@@ -582,4 +582,9 @@ const NSUInteger UIScrollViewScrollAnimationFramesPerSecond = 60;
 {
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; frame = (%.0f %.0f; %.0f %.0f); clipsToBounds = %@; layer = %@; contentOffset = {%.0f, %.0f}>", [self className], self, self.frame.origin.x, self.frame.origin.y, self.frame.size.width, self.frame.size.height, (self.clipsToBounds ? @"YES" : @"NO"), self.layer, self.contentOffset.x, self.contentOffset.y];
+}
+
 @end

--- a/UIKit/Classes/UISlider.m
+++ b/UIKit/Classes/UISlider.m
@@ -42,4 +42,9 @@
 @synthesize minimumValue = _minimumValue;
 @synthesize maximumValue = _maximumValue;
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; frame = (%.0f %.0f; %.0f %.0f); opaque = %@; layer = %@; value = %f>", [self className], self, self.frame.origin.x, self.frame.origin.y, self.frame.size.width, self.frame.size.height, (self.opaque ? @"YES" : @"NO"), self.layer, self.value];
+}
+
 @end

--- a/UIKit/Classes/UIView.m
+++ b/UIKit/Classes/UIView.m
@@ -1041,4 +1041,9 @@ static BOOL _animationsEnabled = YES;
 	_animationsEnabled = enabled;
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; frame = (%.0f %.0f; %.0f %.0f); hidden = %@; layer = %@>", [self className], self, self.frame.origin.x, self.frame.origin.y, self.frame.size.width, self.frame.size.height, (self.hidden ? @"YES" : @"NO"), self.layer];
+}
+
 @end

--- a/UIKit/Classes/UIView.m
+++ b/UIKit/Classes/UIView.m
@@ -1019,4 +1019,9 @@ static BOOL _animationsEnabled = YES;
 	_animationsEnabled = enabled;
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"<%@: %p; frame = (%.0f %.0f; %.0f %.0f); hidden = %@; layer = %@>", [self className], self, self.frame.origin.x, self.frame.origin.y, self.frame.size.width, self.frame.size.height, (self.hidden ? @"YES" : @"NO"), self.layer];
+}
+
 @end


### PR DESCRIPTION
This patch adds a -description implementation to several classes. The implementation matches Apple's in every way possible, and there are comments explaining any discrepancies that may be found.

The following classes were given a -description implementation:
- UIView
- UIColor
- UIGestureRecognizer
- UIScreenMode
- UIScreen
- UIScrollView
- UISlider
