### PR TITLE
add webViewDidFinishLoad:

### DIFF
--- a/UIKit/Classes/UIWebView.h
+++ b/UIKit/Classes/UIWebView.h
@@ -46,6 +46,7 @@ typedef NSUInteger UIWebViewNavigationType;
 @optional
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType;
 - (void)webView:(UIWebView *)aWebView didFailLoadWithError:(NSError *)error;
+- (void)webViewDidFinishLoad:(UIWebView *)webView;
 @end
 
 @interface UIWebView : UIView {
@@ -59,6 +60,7 @@ typedef NSUInteger UIWebViewNavigationType;
 	struct {
 		BOOL shouldStartLoadWithRequest : 1;
 		BOOL didFailLoadWithError : 1;
+        BOOL didFinishLoad : 1;
 	} _delegateHas;
 }
 

--- a/UIKit/Classes/UIWebView.m
+++ b/UIKit/Classes/UIWebView.m
@@ -74,6 +74,7 @@
 	_delegate = newDelegate;
 	_delegateHas.shouldStartLoadWithRequest = [_delegate respondsToSelector:@selector(webView:shouldStartLoadWithRequest:navigationType:)];
 	_delegateHas.didFailLoadWithError = [_delegate respondsToSelector:@selector(webView:didFailLoadWithError:)];
+    _delegateHas.didFinishLoad = [_delegate respondsToSelector:@selector(webViewDidFinishLoad:)];
 }
 
 -(BOOL)becomeFirstResponder
@@ -184,6 +185,13 @@
 
 #pragma mark -
 #pragma mark WebView Frame Load Delegate
+
+- (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
+{
+    if (_delegateHas.didFinishLoad) {
+        [_delegate webViewDidFinishLoad:self];
+    }
+}
 
 - (void)webView:(WebView *)sender didFailLoadWithError:(NSError *)error forFrame:(WebFrame *)frame
 {


### PR DESCRIPTION
This is pretty straight forward. At some point we'll probably want to pay attention to the (WebFrame *)frame arg, however the current delegate methods don't, so this is certainly no worse than the existing code.
