### PR TITLE
Fix double release of UITableViewCell accessoryView

### DIFF
--- a/UIKit/Classes/UITableViewCell.m
+++ b/UIKit/Classes/UITableViewCell.m
@@ -92,7 +92,6 @@ extern CGFloat _UITableViewDefaultRowHeight;
     [_imageView release];
     [_backgroundView release];
     [_selectedBackgroundView release];
-    [_accessoryView release];
     [_reuseIdentifier release];
     [super dealloc];
 }


### PR DESCRIPTION
Fix to remove second call to [_accessoryView release]; in [UITableViewCell dealloc]
