### PR TITLE
Converted all animations to use the block-based methods

### DIFF
--- a/UIKit/Classes/UINavigationBar.m
+++ b/UIKit/Classes/UINavigationBar.m
@@ -165,7 +165,7 @@ typedef enum {
         ];
 
         [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration * .8 
-            delay:kAnimationDuration * .2 
+            delay:!animated ? 0.0 : kAnimationDuration * .2 
             options:0 
             animations:^{
                 _leftView.alpha = 0;
@@ -255,7 +255,7 @@ typedef enum {
         }];
 
         [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration * .8 
-            delay:kAnimationDuration * .2 
+            delay:!animated ? 0.0 : kAnimationDuration * .2 
             options:0 
             animations:^{
                 _leftView.alpha = 1;

--- a/UIKit/Classes/UINavigationBar.m
+++ b/UIKit/Classes/UINavigationBar.m
@@ -141,12 +141,6 @@ typedef enum {
     [self popNavigationItemAnimated:YES];
 }
 
-- (void)_removeAnimatedViews:(NSArray *)views
-{
-    [views makeObjectsPerformSelector:@selector(removeFromSuperview)];
-    [views release];
-}
-
 - (void)_setViewsWithTransition:(_UINavigationBarTransition)transition animated:(BOOL)animated
 {
     {
@@ -155,33 +149,34 @@ typedef enum {
         if (_centerView) [previousViews addObject:_centerView];
         if (_rightView) [previousViews addObject:_rightView];
 
-        if (animated) {
-            CGFloat moveCenterBy = self.bounds.size.width - _centerView.frame.origin.x;
-            CGFloat moveLeftBy = self.bounds.size.width * 0.33f;
+        CGFloat moveCenterBy = self.bounds.size.width - _centerView.frame.origin.x;
+        CGFloat moveLeftBy = self.bounds.size.width * 0.33f;
 
-            if (transition == _UINavigationBarTransitionPush) {
-                moveCenterBy *= -1.f;
-                moveLeftBy *= -1.f;
-            }
-            
-            [UIView beginAnimations:@"move out" context:NULL];
-            [UIView setAnimationDuration:kAnimationDuration];
-            _leftView.frame = CGRectOffset(_leftView.frame, moveLeftBy, 0);
-            _centerView.frame = CGRectOffset(_centerView.frame, moveCenterBy, 0);
-            [UIView commitAnimations];
-
-            [UIView beginAnimations:@"fade out" context:NULL];
-            [UIView setAnimationDuration:kAnimationDuration * .8];
-            [UIView setAnimationDelay:kAnimationDuration * .2];
-            _leftView.alpha = 0;
-            _rightView.alpha = 0;
-            _centerView.alpha = 0;
-            [UIView commitAnimations];
-            
-            [self performSelector:@selector(_removeAnimatedViews:) withObject:previousViews afterDelay:kAnimationDuration];
-        } else {
-            [self _removeAnimatedViews:previousViews];
+        if (transition == _UINavigationBarTransitionPush) {
+            moveCenterBy *= -1.f;
+            moveLeftBy *= -1.f;
         }
+        
+        [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration 
+            animations:^{
+                _leftView.frame = CGRectOffset(_leftView.frame, moveLeftBy, 0);
+                _centerView.frame = CGRectOffset(_centerView.frame, moveCenterBy, 0);
+            }
+        ];
+
+        [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration * .8 
+            delay:kAnimationDuration * .2 
+            options:0 
+            animations:^{
+                _leftView.alpha = 0;
+                _rightView.alpha = 0;
+                _centerView.alpha = 0;
+            }
+            completion:^(BOOL finished){
+                [previousViews makeObjectsPerformSelector:@selector(removeFromSuperview)];
+                [previousViews release];
+            }
+        ];
     }
     
     UINavigationItem *topItem = self.topItem;
@@ -237,38 +232,38 @@ typedef enum {
         _centerView.frame = CGRectMake(kButtonEdgeInsets.left+centerPadding,kButtonEdgeInsets.top,self.bounds.size.width-kButtonEdgeInsets.right-kButtonEdgeInsets.left-centerPadding-centerPadding,kMaxButtonHeight);
         [self addSubview:_centerView];
 
-        if (animated) {
-            CGFloat moveCenterBy = self.bounds.size.width - _centerView.frame.origin.x;
-            CGFloat moveLeftBy = self.bounds.size.width * 0.33f;
+        CGFloat moveCenterBy = self.bounds.size.width - _centerView.frame.origin.x;
+        CGFloat moveLeftBy = self.bounds.size.width * 0.33f;
 
-            if (transition == _UINavigationBarTransitionPush) {
-                moveLeftBy *= -1.f;
-                moveCenterBy *= -1.f;
-            }
+        if (transition == _UINavigationBarTransitionPush) {
+            moveLeftBy *= -1.f;
+            moveCenterBy *= -1.f;
+        }
 
-            CGRect destinationLeftFrame = _leftView.frame;
-            CGRect destinationCenterFrame = _centerView.frame;
-            
-            _leftView.frame = CGRectOffset(_leftView.frame, -moveLeftBy, 0);
-            _centerView.frame = CGRectOffset(_centerView.frame, -moveCenterBy, 0);
-            _leftView.alpha = 0;
-            _rightView.alpha = 0;
-            _centerView.alpha = 0;
-            
-            [UIView beginAnimations:@"move in" context:NULL];
-            [UIView setAnimationDuration:kAnimationDuration];
+        CGRect destinationLeftFrame = _leftView.frame;
+        CGRect destinationCenterFrame = _centerView.frame;
+        
+        _leftView.frame = CGRectOffset(_leftView.frame, -moveLeftBy, 0);
+        _centerView.frame = CGRectOffset(_centerView.frame, -moveCenterBy, 0);
+        _leftView.alpha = 0;
+        _rightView.alpha = 0;
+        _centerView.alpha = 0;
+        
+        [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration animations:^{
             _leftView.frame = destinationLeftFrame;
             _centerView.frame = destinationCenterFrame;
-            [UIView commitAnimations];
-            
-            [UIView beginAnimations:@"fade in" context:NULL];
-            [UIView setAnimationDuration:kAnimationDuration * .8];
-            [UIView setAnimationDelay:kAnimationDuration * .2];
-            _leftView.alpha = 1;
-            _rightView.alpha = 1;
-            _centerView.alpha = 1;
-            [UIView commitAnimations];
-        }
+        }];
+
+        [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration * .8 
+            delay:kAnimationDuration * .2 
+            options:0 
+            animations:^{
+                _leftView.alpha = 1;
+                _rightView.alpha = 1;
+                _centerView.alpha = 1;
+            }
+            completion:nil
+        ];
     } else {
         _leftView = _centerView = _rightView = nil;
     }

--- a/UIKit/Classes/UINavigationController.m
+++ b/UIKit/Classes/UINavigationController.m
@@ -243,23 +243,19 @@ static const CGFloat ToolbarHeight = 28;
             [_delegate navigationController:self willShowViewController:viewController animated:animated];
         }
         
-        if (animated) {
-            viewController.view.frame = nextFrameStart;
-            oldViewController.view.frame = oldFrameStart;
-            
-            [oldViewController retain];
-            
-            [UIView beginAnimations:@"PushViewController" context:(void *)oldViewController];
-            [UIView setAnimationDuration:kAnimationDuration];
-            [UIView setAnimationDelegate:self];
-            [UIView setAnimationDidStopSelector:@selector(_pushAnimationDidStop:finished:removeOldViewController:)];
-            viewController.view.frame = nextFrameEnd;
-            oldViewController.view.frame = oldFrameEnd;
-            [UIView commitAnimations];
-        } else {
-            viewController.view.frame = nextFrameEnd;
-            [oldViewController.view removeFromSuperview];
-        }
+        [oldViewController retain];
+        viewController.view.frame = nextFrameStart;
+        oldViewController.view.frame = oldFrameStart;
+        [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration 
+            animations:^{
+                viewController.view.frame = nextFrameEnd;
+                oldViewController.view.frame = oldFrameEnd;
+            }
+            completion:^(BOOL finished){
+                [oldViewController.view removeFromSuperview];
+                [oldViewController release];
+            }
+        ];
         
         [viewController viewDidAppear:animated];
         if (_delegateHas.didShowViewController) {
@@ -270,12 +266,6 @@ static const CGFloat ToolbarHeight = 28;
     [_viewControllers addObject:viewController];
     [_navigationBar pushNavigationItem:viewController.navigationItem animated:animated];
     [self _updateToolbar:animated];
-}
-
-- (void)_pushAnimationDidStop:(NSString *)name finished:(NSNumber *)finished removeOldViewController:(UIViewController *)controller
-{
-    [controller.view removeFromSuperview];
-    [controller release];
 }
 
 - (UIViewController *)_popViewControllerWithoutPoppingNavigationBarAnimated:(BOOL)animated
@@ -303,23 +293,19 @@ static const CGFloat ToolbarHeight = 28;
                 [_delegate navigationController:self willShowViewController:nextViewController animated:animated];
             }
             
-            if (animated) {
-                nextViewController.view.frame = nextFrameStart;
-                oldViewController.view.frame = oldFrameStart;
-                
-                [oldViewController retain];
-                
-                [UIView beginAnimations:@"PopViewController" context:(void *)oldViewController];
-                [UIView setAnimationDuration:kAnimationDuration];
-                [UIView setAnimationDelegate:self];
-                [UIView setAnimationDidStopSelector:@selector(_popAnimationDidStop:finished:removeOldViewController:)];
-                nextViewController.view.frame = nextFrameEnd;
-                oldViewController.view.frame = oldFrameEnd;
-                [UIView commitAnimations];
-            } else {
-                nextViewController.view.frame = nextFrameEnd;
-                [oldViewController.view removeFromSuperview];
-            }
+            [oldViewController retain];
+            nextViewController.view.frame = nextFrameStart;
+            oldViewController.view.frame = oldFrameStart;
+            [UIView animateWithDuration:!animated ? 0.0 : kAnimationDuration 
+                animations:^{
+                    nextViewController.view.frame = nextFrameEnd;
+                    oldViewController.view.frame = oldFrameEnd;
+                }
+                completion:^(BOOL finished){
+                    [oldViewController.view removeFromSuperview];
+                    [oldViewController release];
+                }
+            ];
             
             [nextViewController viewDidAppear:animated];
             if (_delegateHas.didShowViewController) {
@@ -332,12 +318,6 @@ static const CGFloat ToolbarHeight = 28;
     } else {
         return nil;
     }
-}
-
-- (void)_popAnimationDidStop:(NSString *)name finished:(NSNumber *)finished removeOldViewController:(UIViewController *)controller
-{
-    [controller.view removeFromSuperview];
-    [controller release];
 }
 
 - (UIViewController *)popViewControllerAnimated:(BOOL)animate

--- a/UIKit/Classes/UIPopoverController.m
+++ b/UIKit/Classes/UIPopoverController.m
@@ -251,20 +251,20 @@ static NSPoint PopoverWindowOrigin(NSWindow *inWindow, NSRect fromRect, NSSize p
         [_popoverView pointTo:viewPointTo inView:view];
     }
     
-    if (animated) {
-        _popoverView.transform = CGAffineTransformMakeScale(0.98f,0.98f);
-        _popoverView.alpha = 0.4f;
-        
-        [UIView beginAnimations:@"Ploop" context:NULL];
-        [UIView setAnimationDuration:0.08];
-        _popoverView.transform = CGAffineTransformIdentity;
-        [UIView commitAnimations];
+    _popoverView.transform = CGAffineTransformMakeScale(0.98f,0.98f);
+    _popoverView.alpha = 0.4f;
+    
+    [UIView animateWithDuration:!animated ? 0.0 : 0.08 
+        animations:^{
+            _popoverView.transform = CGAffineTransformIdentity;
+        }
+    ];
 
-        [UIView beginAnimations:@"Fade" context:NULL];
-        [UIView setAnimationDuration:0.1];
-        _popoverView.alpha = 1.f;
-        [UIView commitAnimations];
-    }
+    [UIView animateWithDuration:!animated ? 0.0 : 0.1
+        animations:^{
+            _popoverView.alpha = 1.f;
+        }
+    ];
 }
 
 - (void)presentPopoverFromBarButtonItem:(UIBarButtonItem *)item permittedArrowDirections:(UIPopoverArrowDirection)arrowDirections animated:(BOOL)animated
@@ -276,36 +276,30 @@ static NSPoint PopoverWindowOrigin(NSWindow *inWindow, NSRect fromRect, NSSize p
     return (_popoverView || _popoverWindow || _overlayWindow);
 }
 
-- (void)_destroyPopover
-{
-    [[_overlayWindow parentWindow] makeKeyAndOrderFront:self];
-    
-    [_overlayWindow removeChildWindow:_popoverWindow];
-    [[_overlayWindow parentWindow] removeChildWindow:_overlayWindow];
-    
-    [_popoverView release];
-    [_popoverWindow release];
-    [_overlayWindow release];
-    
-    _popoverView = nil;
-    _popoverWindow = nil;
-    _overlayWindow = nil;
-    
-    _popoverArrowDirection = UIPopoverArrowDirectionUnknown;
-}
-
 - (void)dismissPopoverAnimated:(BOOL)animated
 {
     if ([self isPopoverVisible]) {
-        if (animated) {
-            [UIView beginAnimations:@"dismissPopoverAnimated" context:NULL];
-            [UIView setAnimationDelegate:self];
-            [UIView setAnimationDidStopSelector:@selector(_destroyPopover)];
-            _popoverView.alpha = 0;
-            [UIView commitAnimations];
-        } else {
-            [self _destroyPopover];
-        }
+        [UIView animateWithDuration:!animated ? 0.0 : 0.2 
+            animations:^{
+                _popoverView.alpha = 0;
+            }
+            completion:^(BOOL finished){
+                [[_overlayWindow parentWindow] makeKeyAndOrderFront:self];
+                
+                [_overlayWindow removeChildWindow:_popoverWindow];
+                [[_overlayWindow parentWindow] removeChildWindow:_overlayWindow];
+                
+                [_popoverView release];
+                [_popoverWindow release];
+                [_overlayWindow release];
+                
+                _popoverView = nil;
+                _popoverWindow = nil;
+                _overlayWindow = nil;
+                
+                _popoverArrowDirection = UIPopoverArrowDirectionUnknown;
+            }
+        ];
     }
 }
 

--- a/UIKit/Classes/UIPopoverView.m
+++ b/UIKit/Classes/UIPopoverView.m
@@ -314,9 +314,11 @@ static CGFloat DistanceBetweenTwoPoints(CGPoint A, CGPoint B)
     CGRect frame = self.frame;
     frame.size = [isa frameSizeForContentSize:aSize withNavigationBar:NO];
 
-    if (animated) [UIView beginAnimations:@"setContentSize" context:NULL];
-    self.frame = frame;
-    if (animated) [UIView commitAnimations];
+    [UIView animateWithDuration:!animated ? 0.0 : 0.2
+        animations:^{
+            self.frame = frame;
+        }
+    ];
 }
 
 - (CGSize)contentSize

--- a/UIKit/Classes/UIScrollView.m
+++ b/UIKit/Classes/UIScrollView.m
@@ -550,23 +550,19 @@ const NSUInteger UIScrollViewScrollAnimationFramesPerSecond = 60;
     scale = MIN(MAX(scale, _minimumZoomScale), _maximumZoomScale);
 
     if (zoomingView && self.zoomScale != scale) {
-        if (animated) {
-            [UIView beginAnimations:@"setZoomScale" context:NULL];
-            [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
-            [UIView setAnimationBeginsFromCurrentState:YES];
-            [UIView setAnimationDuration:UIScrollViewAnimationDuration];
-        }
-
-        zoomingView.transform = CGAffineTransformMakeScale(scale, scale);
-        
-        const CGSize size = zoomingView.frame.size;
-        zoomingView.layer.position = CGPointMake(size.width/2.f, size.height/2.f);
-
-        self.contentSize = size;
-        
-        if (animated) {
-            [UIView commitAnimations];
-        }
+        [UIView animateWithDuration:!animated ? 0.0 : UIScrollViewAnimationDuration
+            delay:0
+            options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState
+            animations:^{
+                zoomingView.transform = CGAffineTransformMakeScale(scale, scale);
+                
+                const CGSize size = zoomingView.frame.size;
+                zoomingView.layer.position = CGPointMake(size.width/2.f, size.height/2.f);
+                
+                self.contentSize = size;
+            }
+            completion:nil
+        ];
     }
 }
 

--- a/UIKit/Classes/UIScroller.m
+++ b/UIKit/Classes/UIScroller.m
@@ -75,11 +75,14 @@ CGFloat UIScrollerWidthForBoundsSize(CGSize boundsSize)
     [_fadeTimer invalidate];
     _fadeTimer = nil;
         
-    [UIView beginAnimations:@"fadeOut" context:NULL];
-    [UIView setAnimationDuration:0.33];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
-    self.alpha = _UIScrollerMinimumAlpha;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.33 
+        delay:0
+        options:UIViewAnimationOptionCurveEaseOut
+        animations:^{
+            self.alpha = _UIScrollerMinimumAlpha;
+        }
+        completion:nil
+    ];
 }
 
 - (void)_fadeOutAfterDelay:(NSTimeInterval)time
@@ -93,11 +96,14 @@ CGFloat UIScrollerWidthForBoundsSize(CGSize boundsSize)
     [_fadeTimer invalidate];
     _fadeTimer = nil;
 
-    [UIView beginAnimations:@"fadeIn" context:NULL];
-    [UIView setAnimationDuration:0.33];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
-    self.alpha = 1;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.33 
+        delay:0
+        options:UIViewAnimationOptionCurveEaseOut
+        animations:^{
+            self.alpha = 1.0;
+        }
+        completion:nil
+    ];
 }
 
 - (void)flash

--- a/UIKit/Classes/UIToolbar.m
+++ b/UIKit/Classes/UIToolbar.m
@@ -222,17 +222,16 @@
     if (![self.items isEqualToArray:newItems]) {
         // if animated, fade old item views out, otherwise just remove them
         for (UIToolbarItem *toolbarItem in _toolbarItems) {
-            UIView *view = toolbarItem.view;
+            UIView* view = toolbarItem.view;
             if (view) {
-                if (animated) {
-                    [UIView beginAnimations:@"fadeOut" context:NULL];
-                    [UIView setAnimationDidStopSelector:@selector(removeFromSuperview)];
-                    [UIView setAnimationDelegate:view];
-                    view.alpha = 0;
-                    [UIView commitAnimations];
-                } else {
-                    [view removeFromSuperview];
-                }
+                [UIView animateWithDuration:!animated ? 0.0 : 0.2
+                    animations:^(void) {
+                        view.alpha = 0;
+                    }
+                    completion:^(BOOL finished) {
+                        [view removeFromSuperview];
+                    }
+                ];
             }
         }
         
@@ -241,21 +240,18 @@
         for (UIBarButtonItem *item in newItems) {
             UIToolbarItem *toolbarItem = [[UIToolbarItem alloc] initWithBarButtonItem:item];
             [_toolbarItems addObject:toolbarItem];
-            [self addSubview:toolbarItem.view];
-            [toolbarItem release];
-        }
-                
-        // if animated, fade them in
-        if (animated) {
-            for (UIToolbarItem *toolbarItem in _toolbarItems) {
-                UIView *view = toolbarItem.view;
-                if (view) {
-                    view.alpha = 0;
-                    [UIView beginAnimations:@"fadeIn" context:NULL];
-                    view.alpha = 1;
-                    [UIView commitAnimations];
-                }
+
+            UIView* view = toolbarItem.view;
+            if (view) {
+                view.alpha = 0.0;
+                [self addSubview:view];
+                [UIView animateWithDuration:!animated ? 0.0 : 0.2
+                    animations:^(void) {
+                        view.alpha = 1.0;
+                    }
+                ];
             }
+            [toolbarItem release];
         }
     }
 }

--- a/UIKit/Classes/UITransitionView.m
+++ b/UIKit/Classes/UITransitionView.m
@@ -78,65 +78,40 @@
     }
 }
 
-- (void)_finishTransition:(NSDictionary *)info
+- (void)setView:(UIView *)view
 {
-    UIView *fromView = [info objectForKey:@"fromView"];
-    UIView *toView = [info objectForKey:@"toView"];
-    UITransition transition = [[info objectForKey:@"transition"] intValue];
-    
-    [fromView removeFromSuperview];
+    if (view != _view) {
+        view.frame = [self _rectForIncomingView];
+        [self addSubview:view];
 
-    [_delegate transitionView:self didTransitionFromView:fromView toView:toView withTransition:transition];
-}
-
-- (void)_animation:(NSString *)name didFinish:(NSNumber *)finished info:(NSDictionary *)info
-{
-    [self _finishTransition:info];
-    [info release];
-}
-
-- (void)setView:(UIView *)aView
-{
-    if (aView != _view) {
-        aView.frame = [self _rectForIncomingView];
-        [self addSubview:aView];
-        
-        NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:
-                              _view, @"fromView",
-                              aView, @"toView",
-                              [NSNumber numberWithInt:_transition], @"transition",
-                              nil];
-        
-        if (_transition == UITransitionNone) {
-            [self _finishTransition:info];
-        } else {
-            if (_transition == UITransitionFadeOut) {
-                [self sendSubviewToBack:aView];
-            } else if (_transition == UITransitionFadeIn) {
-                aView.alpha = 0;
-            }
-            
-            [UIView beginAnimations:@"UITransitionView" context:(void *)[info retain]];
-            [UIView setAnimationDidStopSelector:@selector(_animation:didFinish:info:)];
-            [UIView setAnimationDelegate:self];
-            [UIView setAnimationDuration:0.33];
-            
-            _view.frame = [self _rectForOutgoingView];
-            aView.frame = self.bounds;
-            
-            if (_transition == UITransitionFadeOut || _transition == UITransitionCrossFade) {
-                _view.alpha = 0;
-            }
-            
-            if (_transition == UITransitionFadeIn || _transition == UITransitionCrossFade) {
-                aView.alpha = 1;
-            }
-            
-            [UIView commitAnimations];
+        if (_transition == UITransitionFadeOut) {
+            [self sendSubviewToBack:view];
+        } else if (_transition == UITransitionFadeIn) {
+            view.alpha = 0;
         }
         
-        [_view release];
-        _view = [aView retain];
+        [UIView animateWithDuration:0.33 
+            animations:^{
+                if (_transition != UITransitionNone) {
+                    _view.frame = [self _rectForOutgoingView];
+                    view.frame = self.bounds;
+                    
+                    if (_transition == UITransitionFadeOut || _transition == UITransitionCrossFade) {
+                        _view.alpha = 0;
+                    }
+                    
+                    if (_transition == UITransitionFadeIn || _transition == UITransitionCrossFade) {
+                        view.alpha = 1;
+                    }
+                }
+            }
+            completion:^(BOOL finished){
+                [_view removeFromSuperview];
+                [_delegate transitionView:self didTransitionFromView:_view toView:view withTransition:_transition];
+            }
+        ];
+        
+        [_view release], _view = [view retain];
     }
 }
 


### PR DESCRIPTION
Converted all animations to use the block-based methods (for clarity, as well as to ease the deprecation of the beginAnimation/commitAnimation APIs.  From the Apple UIView documentation regarding Animating Views: Use of the methods in this section is discouraged in iOS 4 and later. Use the block-based animation methods instead.
