### PR TITLE
Adds MPMoviePlayer support

### DIFF
--- a/MediaPlayer/Classes/MPMediaPlayback.h
+++ b/MediaPlayer/Classes/MPMediaPlayback.h
@@ -1,0 +1,18 @@
+//
+//  MPMediaPlayback.h
+//  MediaPlayer
+//
+//  Created by Michael Dales on 08/07/2011.
+//  Copyright 2011 Digital Flapjack Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+@protocol MPMediaPlayback <NSObject>
+
+- (void)play;
+- (void)pause;
+- (void)stop;
+
+@end

--- a/MediaPlayer/Classes/MPMoviePlayerController.h
+++ b/MediaPlayer/Classes/MPMoviePlayerController.h
@@ -63,6 +63,7 @@ extern NSString *const MPMoviePlayerPlaybackDidFinishReasonUserInfoKey;
 extern NSString *const MPMoviePlayerPlaybackStateDidChangeNotification;
 extern NSString *const MPMoviePlayerPlaybackDidFinishNotification;
 extern NSString *const MPMoviePlayerLoadStateDidChangeNotification;
+extern NSString *const MPMovieDurationAvailableNotification;
 
 @class UIInternalMovieView;
 
@@ -80,6 +81,7 @@ extern NSString *const MPMoviePlayerLoadStateDidChangeNotification;
 @property (nonatomic) MPMovieSourceType movieSourceType;
 @property (nonatomic, readonly) MPMoviePlaybackState playbackState;
 @property (nonatomic) MPMovieRepeatMode repeatMode;
+@property (nonatomic, readonly) NSTimeInterval duration;
 
 - (id)initWithContentURL: (NSURL*)url;
 

--- a/MediaPlayer/Classes/MPMoviePlayerController.h
+++ b/MediaPlayer/Classes/MPMoviePlayerController.h
@@ -1,0 +1,86 @@
+//
+//  MPMoviewPlayerController.h
+//  MediaPlayer
+//
+//  Created by Michael Dales on 08/07/2011.
+//  Copyright 2011 Digital Flapjack Ltd. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "MPMediaPlayback.h"
+
+#import <QTKit/QTKit.h>
+
+enum {
+    MPMovieLoadStateUnknown        = 0,
+    MPMovieLoadStatePlayable       = 1 << 0,
+    MPMovieLoadStatePlaythroughOK  = 1 << 1,
+    MPMovieLoadStateStalled        = 1 << 2,
+};
+typedef NSInteger MPMovieLoadState;
+
+enum {
+    MPMovieControlStyleNone,
+    MPMovieControlStyleEmbedded,
+    MPMovieControlStyleFullscreen,
+    MPMovieControlStyleDefault = MPMovieControlStyleFullscreen
+};
+typedef NSInteger MPMovieControlStyle;
+
+enum {
+    MPMovieFinishReasonPlaybackEnded,
+    MPMovieFinishReasonPlaybackError,
+    MPMovieFinishReasonUserExited
+};
+typedef NSInteger MPMovieFinishReason;
+
+enum {
+    MPMovieSourceTypeUnknown,
+    MPMovieSourceTypeFile,
+    MPMovieSourceTypeStreaming
+};
+typedef NSInteger MPMovieSourceType;
+
+enum {
+    MPMovieRepeatModeNone,
+    MPMovieRepeatModeOne
+};
+typedef NSInteger MPMovieRepeatMode;
+
+enum {
+    MPMoviePlaybackStateStopped,
+    MPMoviePlaybackStatePlaying,
+    MPMoviePlaybackStatePaused,
+    MPMoviePlaybackStateInterrupted,
+    MPMoviePlaybackStateSeekingForward,
+    MPMoviePlaybackStateSeekingBackward
+};
+typedef NSInteger MPMoviePlaybackState;
+
+extern NSString *const MPMoviePlayerPlaybackDidFinishReasonUserInfoKey;
+
+// notifications
+extern NSString *const MPMoviePlayerPlaybackStateDidChangeNotification;
+extern NSString *const MPMoviePlayerPlaybackDidFinishNotification;
+extern NSString *const MPMoviePlayerLoadStateDidChangeNotification;
+
+@class UIInternalMovieView;
+
+@interface MPMoviePlayerController : NSObject <MPMediaPlayback> 
+{
+@private
+    UIInternalMovieView *movieView;
+    
+    QTMovie *movie;
+}
+@property (nonatomic, readonly) UIView *view;
+@property (nonatomic, readonly) MPMovieLoadState loadState;
+@property (nonatomic, copy) NSURL *contentURL;
+@property (nonatomic) MPMovieControlStyle controlStyle;
+@property (nonatomic) MPMovieSourceType movieSourceType;
+@property (nonatomic, readonly) MPMoviePlaybackState playbackState;
+@property (nonatomic) MPMovieRepeatMode repeatMode;
+
+- (id)initWithContentURL: (NSURL*)url;
+
+@end

--- a/MediaPlayer/Classes/MPMoviePlayerController.h
+++ b/MediaPlayer/Classes/MPMoviePlayerController.h
@@ -57,6 +57,7 @@ enum {
 };
 typedef NSInteger MPMoviePlaybackState;
 
+
 typedef enum {
     MPMovieScalingModeNone,
     MPMovieScalingModeAspectFit,

--- a/MediaPlayer/Classes/MPMoviePlayerController.h
+++ b/MediaPlayer/Classes/MPMoviePlayerController.h
@@ -57,6 +57,13 @@ enum {
 };
 typedef NSInteger MPMoviePlaybackState;
 
+typedef enum {
+    MPMovieScalingModeNone,
+    MPMovieScalingModeAspectFit,
+    MPMovieScalingModeAspectFill,
+    MPMovieScalingModeFill
+} MPMovieScalingMode;
+
 extern NSString *const MPMoviePlayerPlaybackDidFinishReasonUserInfoKey;
 
 // notifications
@@ -82,6 +89,7 @@ extern NSString *const MPMovieDurationAvailableNotification;
 @property (nonatomic, readonly) MPMoviePlaybackState playbackState;
 @property (nonatomic) MPMovieRepeatMode repeatMode;
 @property (nonatomic, readonly) NSTimeInterval duration;
+@property (nonatomic) MPMovieScalingMode scalingMode;
 
 - (id)initWithContentURL: (NSURL*)url;
 

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -108,6 +108,8 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 {
     if (notification.object != movie)
         return;
+
+    _playbackState = MPMoviePlaybackStateStopped;
     
     [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerPlaybackDidFinishNotification
                                                         object: self];
@@ -180,6 +182,7 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 - (void)play
 {
     [movie play];
+    _playbackState = MPMoviePlaybackStatePlaying;
 }
 
 
@@ -187,7 +190,8 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 //
 - (void)pause
 {
-    //[movie pause];
+    [movie stop];
+    _playbackState = MPMoviePlaybackStatePaused;
 }
 
 
@@ -196,6 +200,7 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 - (void)stop
 {
     [movie stop];
+    _playbackState = MPMoviePlaybackStateStopped;
 }
 
 @end

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -26,6 +26,17 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 @synthesize movieSourceType=_movieSourceType;
 @synthesize playbackState=_playbackState;
 @synthesize repeatMode=_repeatMode;
+@synthesize scalingMode=_scalingMode;
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)setScalingMode:(MPMovieScalingMode)scalingMode
+{
+    _scalingMode = scalingMode;
+    movieView.scalingMode = scalingMode;
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -148,6 +159,8 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
                                        error: &error];
         
         movieView = [[UIInternalMovieView alloc] initWithMovie: movie];
+        
+        self.scalingMode = MPMovieScalingModeAspectFit;
         
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(loadStateChangeOccurred:)

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -78,9 +78,32 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 {    
     NSNumber* loadState = [movie attributeForKey: QTMovieLoadStateAttribute];        
     
+    NSLog(@"load state: %@", loadState);
+    
     switch ([loadState intValue]) {
         case QTMovieLoadStateError:            
-        case QTMovieLoadStateLoading:              
+        {
+            NSLog(@"woo");
+            NSNumber *stopCode = [NSNumber numberWithInt: MPMovieFinishReasonPlaybackError];
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject: stopCode
+                                                                 forKey: MPMoviePlayerPlaybackDidFinishReasonUserInfoKey];
+            
+            // if there's a loading error we generate a stop notification
+            [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerPlaybackDidFinishNotification
+                                                                object: self 
+                                                              userInfo: userInfo];
+            
+            
+            _loadState = MPMovieLoadStateUnknown;                        
+        }
+            break;
+
+        
+        
+        case QTMovieLoadStateLoading:             
+            _loadState = MPMovieLoadStateUnknown;            
+            break;
+            
     
         
         case QTMovieLoadStateLoaded:            
@@ -121,9 +144,14 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
         return;
 
     _playbackState = MPMoviePlaybackStateStopped;
+        
+    NSNumber *stopCode = [NSNumber numberWithInt: MPMovieFinishReasonPlaybackEnded];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject: stopCode
+                                                         forKey: MPMoviePlayerPlaybackDidFinishReasonUserInfoKey];
     
     [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerPlaybackDidFinishNotification
-                                                        object: self];
+                                                        object: self
+                                                      userInfo: userInfo];
 }
 
 
@@ -134,6 +162,8 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
     if (notification.object != movie)
         return;
         
+    NSLog(@"nnnnnnnnn");
+    
     [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerLoadStateDidChangeNotification
                                                         object: self];
 }

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -78,8 +78,6 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 {    
     NSNumber* loadState = [movie attributeForKey: QTMovieLoadStateAttribute];        
     
-    NSLog(@"load state: %@", loadState);
-    
     switch ([loadState intValue]) {
         case QTMovieLoadStateError:            
         {
@@ -162,8 +160,6 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
     if (notification.object != movie)
         return;
         
-    NSLog(@"nnnnnnnnn");
-    
     [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerLoadStateDidChangeNotification
                                                         object: self];
 }

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -27,6 +27,17 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 @synthesize playbackState=_playbackState;
 @synthesize repeatMode=_repeatMode;
 
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)setRepeatMode:(MPMovieRepeatMode)repeatMode
+{
+    _repeatMode = repeatMode;
+    [movie setAttribute: [NSNumber numberWithBool: repeatMode == MPMovieRepeatModeOne]
+                 forKey: QTMovieLoopsAttribute];
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 - (NSTimeInterval)duration
@@ -97,9 +108,6 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 {
     if (notification.object != movie)
         return;
-    
-    if (self.repeatMode == MPMovieRepeatModeOne)
-        [self play];
     
     [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerPlaybackDidFinishNotification
                                                         object: self];

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -1,0 +1,170 @@
+//
+//  MPMoviewPlayerController.m
+//  MediaPlayer
+//
+//  Created by Michael Dales on 08/07/2011.
+//  Copyright 2011 Digital Flapjack Ltd. All rights reserved.
+//
+
+#import "MPMoviePlayerController.h"
+#import "UIInternalMovieView.h"
+
+NSString *const MPMoviePlayerPlaybackDidFinishReasonUserInfoKey = @"MPMoviePlayerPlaybackDidFinishReasonUserInfoKey";
+
+// notifications
+NSString *const MPMoviePlayerPlaybackStateDidChangeNotification = @"MPMoviePlayerPlaybackStateDidChangeNotification";
+NSString *const MPMoviePlayerPlaybackDidFinishNotification = @"MPMoviePlayerPlaybackDidFinishNotification";
+NSString *const MPMoviePlayerLoadStateDidChangeNotification = @"MPMoviePlayerLoadStateDidChangeNotification";
+
+@implementation MPMoviePlayerController
+
+@synthesize view=_view;
+@synthesize loadState=_loadState;
+@synthesize contentURL=_contentURL;
+@synthesize controlStyle=_controlStyle;
+@synthesize movieSourceType=_movieSourceType;
+@synthesize playbackState=_playbackState;
+@synthesize repeatMode=_repeatMode;
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (UIView*)view
+{
+    return movieView;
+}
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (MPMovieLoadState)loadState
+{    
+    NSNumber* loadState = [movie attributeForKey: QTMovieLoadStateAttribute];        
+    
+    switch ([loadState intValue]) {
+        case QTMovieLoadStateError:            
+        case QTMovieLoadStateLoading:              
+        case QTMovieLoadStateLoaded:            
+            _loadState = MPMovieLoadStateUnknown;            
+            break;
+            
+        case QTMovieLoadStatePlayable:
+            _loadState = MPMovieLoadStatePlayable;
+            break;
+            
+        case QTMovieLoadStatePlaythroughOK:
+            _loadState = MPMovieLoadStatePlaythroughOK;            
+            break;
+            
+        case QTMovieLoadStateComplete:
+            _loadState = MPMovieLoadStatePlaythroughOK;
+            
+            break;                                
+    }
+    
+    return _loadState;
+}
+
+
+#pragma mark - notifications
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)didEndOccurred: (NSNotification*)notification
+{
+    if (notification.object != movie)
+        return;
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerPlaybackDidFinishNotification
+                                                        object: self];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)loadStateChangeOccurred: (NSNotification*)notification
+{
+    if (notification.object != movie)
+        return;
+        
+    [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerLoadStateDidChangeNotification
+                                                        object: self];
+}
+
+#pragma mark - constructor/destructor
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (id)initWithContentURL:(NSURL *)url
+{
+    self = [super init];
+    if (self) 
+    {
+        _contentURL = [url retain];
+        _loadState = MPMovieLoadStateUnknown;
+        _controlStyle = MPMovieControlStyleDefault;
+        _movieSourceType = MPMovieSourceTypeUnknown;
+        _playbackState = MPMoviePlaybackStateStopped;
+        _repeatMode = MPMovieRepeatModeNone;
+        
+        NSError *error = nil;
+        movie = [[QTMovie alloc] initWithURL: url
+                                       error: &error];
+        
+        movieView = [[UIInternalMovieView alloc] initWithMovie: movie];
+        
+        [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(loadStateChangeOccurred:)
+                                                     name: QTMovieLoadStateDidChangeNotification
+                                                   object: nil];
+        
+        [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(didEndOccurred:)
+                                                     name: QTMovieDidEndNotification 
+                                                   object: nil];
+    }
+    
+    return self;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)dealloc
+{
+    [_view release];
+    [super dealloc];
+}
+
+
+#pragma mark - MPMediaPlayback
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)play
+{
+    [movie play];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)pause
+{
+    //[movie pause];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)stop
+{
+    [movie stop];
+}
+
+@end

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -136,6 +136,7 @@ NSString *const MPMoviePlayerLoadStateDidChangeNotification = @"MPMoviePlayerLoa
 //
 - (void)dealloc
 {
+    [[NSNotificationCenter defaultCenter] removeObserver: self];
     [_view release];
     [super dealloc];
 }

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -15,6 +15,7 @@ NSString *const MPMoviePlayerPlaybackDidFinishReasonUserInfoKey = @"MPMoviePlaye
 NSString *const MPMoviePlayerPlaybackStateDidChangeNotification = @"MPMoviePlayerPlaybackStateDidChangeNotification";
 NSString *const MPMoviePlayerPlaybackDidFinishNotification = @"MPMoviePlayerPlaybackDidFinishNotification";
 NSString *const MPMoviePlayerLoadStateDidChangeNotification = @"MPMoviePlayerLoadStateDidChangeNotification";
+NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailableNotification";
 
 @implementation MPMoviePlayerController
 
@@ -26,6 +27,18 @@ NSString *const MPMoviePlayerLoadStateDidChangeNotification = @"MPMoviePlayerLoa
 @synthesize playbackState=_playbackState;
 @synthesize repeatMode=_repeatMode;
 
+///////////////////////////////////////////////////////////////////////////////
+//
+- (NSTimeInterval)duration
+{
+    QTTime time = [movie duration];
+    NSTimeInterval interval;
+    
+    if (QTGetTimeInterval(time, &interval))
+        return interval;
+    else
+        return 0.0;
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,7 +59,13 @@ NSString *const MPMoviePlayerLoadStateDidChangeNotification = @"MPMoviePlayerLoa
     switch ([loadState intValue]) {
         case QTMovieLoadStateError:            
         case QTMovieLoadStateLoading:              
+    
+        
         case QTMovieLoadStateLoaded:            
+            // we have the meta data, so post the duration available notification
+            [[NSNotificationCenter defaultCenter] postNotificationName: MPMovieDurationAvailableNotification
+                                                                object: self];
+            
             _loadState = MPMovieLoadStateUnknown;            
             break;
             
@@ -78,6 +97,9 @@ NSString *const MPMoviePlayerLoadStateDidChangeNotification = @"MPMoviePlayerLoa
 {
     if (notification.object != movie)
         return;
+    
+    if (self.repeatMode == MPMovieRepeatModeOne)
+        [self play];
     
     [[NSNotificationCenter defaultCenter] postNotificationName: MPMoviePlayerPlaybackDidFinishNotification
                                                         object: self];

--- a/MediaPlayer/Classes/MediaPlayer.h
+++ b/MediaPlayer/Classes/MediaPlayer.h
@@ -28,3 +28,4 @@
  */
 
 #import "MPMusicPlayerController.h"
+#import "MPMoviePlayerController.h"

--- a/MediaPlayer/Classes/UIInternalMovieView.h
+++ b/MediaPlayer/Classes/UIInternalMovieView.h
@@ -9,11 +9,15 @@
 #import <UIKit/UIKit.h>
 #import <QTKit/QTKit.h>
 
+#import "MPMoviePlayerController.h"
+
+
 @interface UIInternalMovieView : UIView {
 @private
     QTMovieLayer *movieLayer;
 }
 @property (nonatomic, retain) QTMovie* movie;
+@property (nonatomic, assign) MPMovieScalingMode scalingMode;
 
 - (id)initWithMovie: (QTMovie*)movie;
 

--- a/MediaPlayer/Classes/UIInternalMovieView.h
+++ b/MediaPlayer/Classes/UIInternalMovieView.h
@@ -1,0 +1,20 @@
+//
+//  UIInternalMovieView.h
+//  MediaPlayer
+//
+//  Created by Michael Dales on 08/07/2011.
+//  Copyright 2011 Digital Flapjack Ltd. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <QTKit/QTKit.h>
+
+@interface UIInternalMovieView : UIView {
+@private
+    QTMovieLayer *movieLayer;
+}
+@property (nonatomic, retain) QTMovie* movie;
+
+- (id)initWithMovie: (QTMovie*)movie;
+
+@end

--- a/MediaPlayer/Classes/UIInternalMovieView.m
+++ b/MediaPlayer/Classes/UIInternalMovieView.m
@@ -12,6 +12,36 @@
 @implementation UIInternalMovieView
 
 @synthesize movie=_movie;
+@synthesize scalingMode=_scalingMode;
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)setScalingMode:(MPMovieScalingMode)scalingMode
+{
+    _scalingMode = scalingMode;
+    
+    switch (scalingMode)
+    {
+        case MPMovieScalingModeNone:
+            movieLayer.contentsGravity = kCAGravityCenter;
+            break;
+            
+        case MPMovieScalingModeAspectFit:
+            movieLayer.contentsGravity = kCAGravityResizeAspect;
+            break;
+            
+        case MPMovieScalingModeAspectFill:
+            movieLayer.contentsGravity = kCAGravityResizeAspectFill;
+            break;
+            
+        case MPMovieScalingModeFill:
+            movieLayer.contentsGravity = kCAGravityResize;
+            break;
+            
+    }
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/MediaPlayer/Classes/UIInternalMovieView.m
+++ b/MediaPlayer/Classes/UIInternalMovieView.m
@@ -1,0 +1,51 @@
+//
+//  UIInternalMovieView.m
+//  MediaPlayer
+//
+//  Created by Michael Dales on 08/07/2011.
+//  Copyright 2011 Digital Flapjack Ltd. All rights reserved.
+//
+
+#import "UIInternalMovieView.h"
+
+
+@implementation UIInternalMovieView
+
+@synthesize movie=_movie;
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (id)initWithMovie:(QTMovie *)movie
+{
+    if ((self = [super init]) != nil)
+    {
+        self.movie = movie;
+        
+        movieLayer = [[QTMovieLayer alloc] initWithMovie: movie];
+        
+        [self.layer addSublayer: movieLayer];
+    }
+    
+    return self;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)dealloc
+{
+    [_movie release];
+    [super dealloc];
+}
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)setFrame:(CGRect)frame
+{
+    [super setFrame: frame];
+    [movieLayer setFrame: frame];
+}
+
+@end

--- a/MediaPlayer/MediaPlayer.xcodeproj/project.pbxproj
+++ b/MediaPlayer/MediaPlayer.xcodeproj/project.pbxproj
@@ -11,7 +11,24 @@
 		14C25F001211ED4C00622309 /* MPMusicPlayerController.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C25EFE1211ED4C00622309 /* MPMusicPlayerController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14C25F011211ED4C00622309 /* MPMusicPlayerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 14C25EFF1211ED4C00622309 /* MPMusicPlayerController.m */; };
 		14EFB1BB1211DB5300D19B0C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14EFB1BA1211DB5300D19B0C /* Cocoa.framework */; };
+		4C1677D913C70F1A00814195 /* MPMoviePlayerController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C1677D713C70F1900814195 /* MPMoviePlayerController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C1677DA13C70F1A00814195 /* MPMoviePlayerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1677D813C70F1900814195 /* MPMoviePlayerController.m */; };
+		4C16781613C71E4900814195 /* MPMediaPlayback.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C16781513C71E4900814195 /* MPMediaPlayback.h */; };
+		4C16781A13C71E6200814195 /* UIInternalMovieView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C16781813C71E6200814195 /* UIInternalMovieView.h */; };
+		4C16781B13C71E6200814195 /* UIInternalMovieView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C16781913C71E6200814195 /* UIInternalMovieView.m */; };
+		4C16787D13C71FB900814195 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C16787C13C71FB900814195 /* UIKit.framework */; };
+		4C16789F13C7206500814195 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C16789E13C7206500814195 /* QTKit.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4C16787913C71F8A00814195 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4C16787213C71F8A00814195 /* UIKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8DC2EF5B0486A6940098B216;
+			remoteInfo = UIKit;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		0867D69BFE84028FC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
@@ -21,6 +38,14 @@
 		14C25EFE1211ED4C00622309 /* MPMusicPlayerController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPMusicPlayerController.h; path = Classes/MPMusicPlayerController.h; sourceTree = "<group>"; };
 		14C25EFF1211ED4C00622309 /* MPMusicPlayerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MPMusicPlayerController.m; path = Classes/MPMusicPlayerController.m; sourceTree = "<group>"; };
 		14EFB1BA1211DB5300D19B0C /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		4C1677D713C70F1900814195 /* MPMoviePlayerController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPMoviePlayerController.h; path = Classes/MPMoviePlayerController.h; sourceTree = "<group>"; };
+		4C1677D813C70F1900814195 /* MPMoviePlayerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MPMoviePlayerController.m; path = Classes/MPMoviePlayerController.m; sourceTree = "<group>"; };
+		4C16781513C71E4900814195 /* MPMediaPlayback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPMediaPlayback.h; path = Classes/MPMediaPlayback.h; sourceTree = "<group>"; };
+		4C16781813C71E6200814195 /* UIInternalMovieView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIInternalMovieView.h; path = Classes/UIInternalMovieView.h; sourceTree = "<group>"; };
+		4C16781913C71E6200814195 /* UIInternalMovieView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UIInternalMovieView.m; path = Classes/UIInternalMovieView.m; sourceTree = "<group>"; };
+		4C16787213C71F8A00814195 /* UIKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UIKit.xcodeproj; path = ../UIKit/UIKit.xcodeproj; sourceTree = "<group>"; };
+		4C16787C13C71FB900814195 /* UIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UIKit.framework; sourceTree = SOURCE_ROOT; };
+		4C16789E13C7206500814195 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = System/Library/Frameworks/QTKit.framework; sourceTree = SDKROOT; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* MediaPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MediaPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -30,6 +55,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C16789F13C7206500814195 /* QTKit.framework in Frameworks */,
+				4C16787D13C71FB900814195 /* UIKit.framework in Frameworks */,
 				14EFB1BB1211DB5300D19B0C /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -48,11 +75,15 @@
 		0867D691FE84028FC02AAC07 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				4C16789E13C7206500814195 /* QTKit.framework */,
+				4C16787C13C71FB900814195 /* UIKit.framework */,
 				08FB77AEFE84172EC02AAC07 /* Classes */,
+				4C16780A13C71DDC00814195 /* Private Classes */,
 				089C1665FE841158C02AAC07 /* Resources */,
 				32C88DFF0371C24200C91783 /* Other Sources */,
 				0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */,
 				034768DFFF38A50411DB9C8B /* Products */,
+				4C16787213C71F8A00814195 /* UIKit.xcodeproj */,
 			);
 			name = UIKit;
 			sourceTree = "<group>";
@@ -81,6 +112,9 @@
 				14C25EF21211ED0400622309 /* MediaPlayer.h */,
 				14C25EFE1211ED4C00622309 /* MPMusicPlayerController.h */,
 				14C25EFF1211ED4C00622309 /* MPMusicPlayerController.m */,
+				4C1677D713C70F1900814195 /* MPMoviePlayerController.h */,
+				4C1677D813C70F1900814195 /* MPMoviePlayerController.m */,
+				4C16781513C71E4900814195 /* MPMediaPlayback.h */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -93,6 +127,23 @@
 			name = "Other Sources";
 			sourceTree = "<group>";
 		};
+		4C16780A13C71DDC00814195 /* Private Classes */ = {
+			isa = PBXGroup;
+			children = (
+				4C16781813C71E6200814195 /* UIInternalMovieView.h */,
+				4C16781913C71E6200814195 /* UIInternalMovieView.m */,
+			);
+			name = "Private Classes";
+			sourceTree = "<group>";
+		};
+		4C16787313C71F8A00814195 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4C16787A13C71F8A00814195 /* UIKit.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -102,6 +153,9 @@
 			files = (
 				14C25EF31211ED0400622309 /* MediaPlayer.h in Headers */,
 				14C25F001211ED4C00622309 /* MPMusicPlayerController.h in Headers */,
+				4C1677D913C70F1A00814195 /* MPMoviePlayerController.h in Headers */,
+				4C16781613C71E4900814195 /* MPMediaPlayback.h in Headers */,
+				4C16781A13C71E6200814195 /* UIInternalMovieView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -145,12 +199,28 @@
 			mainGroup = 0867D691FE84028FC02AAC07 /* UIKit */;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 4C16787313C71F8A00814195 /* Products */;
+					ProjectRef = 4C16787213C71F8A00814195 /* UIKit.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				8DC2EF4F0486A6940098B216 /* MediaPlayer */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		4C16787A13C71F8A00814195 /* UIKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = UIKit.framework;
+			remoteRef = 4C16787913C71F8A00814195 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		8DC2EF520486A6940098B216 /* Resources */ = {
@@ -168,6 +238,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				14C25F011211ED4C00622309 /* MPMusicPlayerController.m in Sources */,
+				4C1677DA13C70F1A00814195 /* MPMoviePlayerController.m in Sources */,
+				4C16781B13C71E6200814195 /* UIInternalMovieView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -181,6 +253,10 @@
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
 				FRAMEWORK_VERSION = A;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
@@ -204,6 +280,10 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
 				FRAMEWORK_VERSION = A;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/MediaPlayer/MediaPlayer.xcodeproj/project.pbxproj
+++ b/MediaPlayer/MediaPlayer.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4C16781B13C71E6200814195 /* UIInternalMovieView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C16781913C71E6200814195 /* UIInternalMovieView.m */; };
 		4C16787D13C71FB900814195 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C16787C13C71FB900814195 /* UIKit.framework */; };
 		4C16789F13C7206500814195 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C16789E13C7206500814195 /* QTKit.framework */; };
+		4C72FDF613C746E800D3E453 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C72FDF513C746E800D3E453 /* QuartzCore.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		4C16787213C71F8A00814195 /* UIKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UIKit.xcodeproj; path = ../UIKit/UIKit.xcodeproj; sourceTree = "<group>"; };
 		4C16787C13C71FB900814195 /* UIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UIKit.framework; sourceTree = SOURCE_ROOT; };
 		4C16789E13C7206500814195 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = System/Library/Frameworks/QTKit.framework; sourceTree = SDKROOT; };
+		4C72FDF513C746E800D3E453 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* MediaPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MediaPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -55,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C72FDF613C746E800D3E453 /* QuartzCore.framework in Frameworks */,
 				4C16789F13C7206500814195 /* QTKit.framework in Frameworks */,
 				4C16787D13C71FB900814195 /* UIKit.framework in Frameworks */,
 				14EFB1BB1211DB5300D19B0C /* Cocoa.framework in Frameworks */,
@@ -75,6 +78,7 @@
 		0867D691FE84028FC02AAC07 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				4C72FDF513C746E800D3E453 /* QuartzCore.framework */,
 				4C16789E13C7206500814195 /* QTKit.framework */,
 				4C16787C13C71FB900814195 /* UIKit.framework */,
 				08FB77AEFE84172EC02AAC07 /* Classes */,


### PR DESCRIPTION
Adds a wrapper for QTMovieLayer to provide MPMoviePlayer. Not complement, but it has sufficient functionality that I was able to port the "CODA Player" iOS app, a soft of mini-digital signage app, to the Mac and have it function correctly.

Could be convinced to work some more on it, but thought I should see if you were interested first :)

Regardless, most the initial work is here, and this is certainly enough to let you display videos.
