### PR TITLE
Suppress compiler errors for ARC directives.

### DIFF
--- a/UIKit/UIKit_Prefix.pch
+++ b/UIKit/UIKit_Prefix.pch
@@ -30,3 +30,13 @@
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
 #endif
+
+// If ARC is not enabled, declare empty ARC directives to supress compiler errors
+#ifndef __has_feature
+  #define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
+
+#if !__has_feature(objc_arc)
+  #define __unsafe_unretained
+  #define __bridge
+#endif


### PR DESCRIPTION
I'm not sure if you'd like to use this patch as a temporary (or even permanent solution) for those who wish to continue to compile Chameleon under 10.6.

Patch checks to see if ARC is supported / enabled. If it is not, it declares the __bridge and __unsafe_unretained directives as empty macros.

Enrique
