### PR TITLE
Fixes UIView's contentStretch property

### DIFF
--- a/UIKit/Classes/UIView.m
+++ b/UIKit/Classes/UIView.m
@@ -762,14 +762,14 @@ static BOOL _animationsEnabled = YES;
 
 - (void)setContentStretch:(CGRect)rect
 {
-    if (!CGRectEqualToRect(rect,_layer.contentsRect)) {
-        _layer.contentsRect = rect;
+    if (!CGRectEqualToRect(rect,_layer.contentsCenter)) {
+        _layer.contentsCenter = rect;
     }
 }
 
 - (CGRect)contentStretch
 {
-    return _layer.contentsRect;
+    return _layer.contentsCenter;
 }
 
 - (void)setHidden:(BOOL)h

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -1235,6 +1235,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1258,6 +1259,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -36,7 +36,9 @@
       displayScale = "1.00"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -46,7 +48,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release">
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
Content stretch is broken because UIView sets the wrong property on its underlying CALayer when setting the contentStretch property. This change corrects this by making UIView set/get the correct CALayer property.
