### PR TITLE
Missing iOS 3.2 MPMoviePlayer methods and properties

### DIFF
--- a/MediaPlayer/Classes/MPMediaPlayback.h
+++ b/MediaPlayer/Classes/MPMediaPlayback.h
@@ -13,6 +13,7 @@
 
 - (void)play;
 - (void)pause;
+- (void)prepareToPlay;
 - (void)stop;
 
 @end

--- a/MediaPlayer/Classes/MPMoviePlayerController.h
+++ b/MediaPlayer/Classes/MPMoviePlayerController.h
@@ -87,10 +87,19 @@ extern NSString *const MPMovieDurationAvailableNotification;
 @property (nonatomic, copy) NSURL *contentURL;
 @property (nonatomic) MPMovieControlStyle controlStyle;
 @property (nonatomic) MPMovieSourceType movieSourceType;
+
+// A view for customization which is always displayed behind movie content.
+@property(nonatomic, readonly) UIView *backgroundView;
+
 @property (nonatomic, readonly) MPMoviePlaybackState playbackState;
 @property (nonatomic) MPMovieRepeatMode repeatMode;
+
+// Indicates if a movie should automatically start playback when it is likely to finish uninterrupted based on e.g. network conditions. Defaults to YES.
+@property(nonatomic) BOOL shouldAutoplay;
+
 @property (nonatomic, readonly) NSTimeInterval duration;
 @property (nonatomic) MPMovieScalingMode scalingMode;
+
 
 - (id)initWithContentURL: (NSURL*)url;
 

--- a/MediaPlayer/Classes/MPMoviePlayerController.m
+++ b/MediaPlayer/Classes/MPMoviePlayerController.m
@@ -24,8 +24,10 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
 @synthesize contentURL=_contentURL;
 @synthesize controlStyle=_controlStyle;
 @synthesize movieSourceType=_movieSourceType;
+@synthesize backgroundView;
 @synthesize playbackState=_playbackState;
 @synthesize repeatMode=_repeatMode;
+@synthesize shouldAutoplay;
 @synthesize scalingMode=_scalingMode;
 
 
@@ -233,6 +235,11 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
     _playbackState = MPMoviePlaybackStatePaused;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+//
+- (void)prepareToPlay {
+    // Do nothing
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -241,5 +248,17 @@ NSString *const MPMovieDurationAvailableNotification = @"MPMovieDurationAvailabl
     [movie stop];
     _playbackState = MPMoviePlaybackStateStopped;
 }
+
+#pragma mark - Pending
+
+- (void) setShouldAutoplay:(BOOL)shouldAutoplay {
+    NSLog(@"[CHAMELEON] MPMoviePlayerController.shouldAutoplay not implemented");
+}
+
+- (UIView*) backgroundView {
+    NSLog(@"[CHAMELEON] MPMoviePlayerController.backgroundView not implemented");
+    return nil;
+}
+
 
 @end


### PR DESCRIPTION
Added the following methods and properties with dummy implementations:

prepareToPlay
backgroundView
shouldAutoplay
