### PR TITLE
NSCoder Serialization for CGRects

### DIFF
--- a/UIKit/Classes/UIGeometry.h
+++ b/UIKit/Classes/UIGeometry.h
@@ -93,4 +93,6 @@ NSString *NSStringFromUIOffset(UIOffset offset);
 @interface NSCoder (NSCoderUIGeometryExtensions)
 - (void)encodeCGPoint:(CGPoint)point forKey:(NSString *)key;
 - (CGPoint)decodeCGPointForKey:(NSString *)key;
+- (void)encodeCGRect:(CGRect)rect forKey:(NSString *)key;
+- (CGRect)decodeCGRectForKey:(NSString *)key;
 @end

--- a/UIKit/Classes/UIGeometry.m
+++ b/UIKit/Classes/UIGeometry.m
@@ -136,6 +136,17 @@ NSString *NSStringFromUIOffset(UIOffset offset)
 {
     return NSPointToCGPoint([self decodePointForKey:key]);
 }
+
+- (void)encodeCGRect:(CGRect)rect forKey:(NSString *)key
+{
+    [self encodeRect:NSRectFromCGRect(rect) forKey:key];
+}
+
+- (CGRect)decodeCGRectForKey:(NSString *)key
+{
+    return NSRectToCGRect([self decodeRectForKey:key]);
+}
+
 @end
 
 


### PR DESCRIPTION
I copied the methods for encodeCGPoint:forKey and decodCGPoint:forKey and made them work for CGRects.  I tested it out and worked fine for keyed archives I made on ios 6.
